### PR TITLE
Refactor ChainOfRespLambda

### DIFF
--- a/src/main/java/org/mfusco/fromgoftolambda/examples/chainofresponsibility/ChainOfRespLambda.java
+++ b/src/main/java/org/mfusco/fromgoftolambda/examples/chainofresponsibility/ChainOfRespLambda.java
@@ -7,27 +7,27 @@ import java.util.stream.Stream;
 public class ChainOfRespLambda {
 
     public static Optional<String> parseText(File file) {
-        return file.getType() == File.Type.TEXT ?
-               Optional.of("Text file: " + file.getContent()) :
-               Optional.empty();
+        return Optional.ofNullable(file)
+          .filter(f -> f.getType() == File.Type.TEXT )
+          .map(f -> "Text file: " + f.getContent());
     }
 
     public static Optional<String> parsePresentation(File file) {
-        return file.getType() == File.Type.PRESENTATION ?
-               Optional.of("Presentation file: " + file.getContent()) :
-               Optional.empty();
+        return Optional.ofNullable(file)
+          .filter(f -> f.getType() == File.Type.PRESENTATION )
+          .map(f -> "Presentation file: " + f.getContent());
     }
 
     public static Optional<String> parseAudio(File file) {
-        return file.getType() == File.Type.AUDIO ?
-               Optional.of("Audio file: " + file.getContent()) :
-               Optional.empty();
+        return Optional.ofNullable(file)
+          .filter(f -> f.getType() == File.Type.AUDIO )
+          .map(f -> "Audio file: " + f.getContent());
     }
 
     public static Optional<String> parseVideo(File file) {
-        return file.getType() == File.Type.VIDEO ?
-               Optional.of("Video file: " + file.getContent()) :
-               Optional.empty();
+        return Optional.ofNullable(file)
+          .filter(f -> f.getType() == File.Type.VIDEO )
+          .map(f -> "Video file: " + f.getContent());
     }
 
     public static void main( String[] args ) {
@@ -41,9 +41,9 @@ public class ChainOfRespLambda {
                 ChainOfRespLambda::parseVideo )
                 .map(f -> f.apply( file ))
                 .filter( Optional::isPresent )
+                .map( Optional::get )
                 .findFirst()
-                .flatMap( Function.identity() )
                 .orElseThrow( () -> new RuntimeException( "Unknown file: " + file ) )
-                          );
+        );
     }
 }


### PR DESCRIPTION
- Avoided NPE in _parse*_ methods by applying Optional.ofNullable
- Avoided _if-else_ in _parse*_ methods by using Optional's map()
- Avoided _flatmap()_ by unwrapping values in Optionals (easier to understand by the audience)