### PR TITLE
Improve ChainOfRespLambda

### DIFF
--- a/src/main/java/org/mfusco/fromgoftolambda/examples/chainofresponsibility/ChainOfRespLambda.java
+++ b/src/main/java/org/mfusco/fromgoftolambda/examples/chainofresponsibility/ChainOfRespLambda.java
@@ -7,27 +7,27 @@ import java.util.stream.Stream;
 public class ChainOfRespLambda {
 
     public static Optional<String> parseText(File file) {
-        return Optional.ofNullable(file)
-          .filter(f -> f.getType() == File.Type.TEXT )
-          .map(f -> "Text file: " + f.getContent());
+        return file.getType() == File.Type.TEXT ?
+               Optional.of("Text file: " + file.getContent()) :
+               Optional.empty();
     }
 
     public static Optional<String> parsePresentation(File file) {
-        return Optional.ofNullable(file)
-          .filter(f -> f.getType() == File.Type.PRESENTATION )
-          .map(f -> "Presentation file: " + f.getContent());
+        return file.getType() == File.Type.PRESENTATION ?
+               Optional.of("Presentation file: " + file.getContent()) :
+               Optional.empty();
     }
 
     public static Optional<String> parseAudio(File file) {
-        return Optional.ofNullable(file)
-          .filter(f -> f.getType() == File.Type.AUDIO )
-          .map(f -> "Audio file: " + f.getContent());
+        return file.getType() == File.Type.AUDIO ?
+               Optional.of("Audio file: " + file.getContent()) :
+               Optional.empty();
     }
 
     public static Optional<String> parseVideo(File file) {
-        return Optional.ofNullable(file)
-          .filter(f -> f.getType() == File.Type.VIDEO )
-          .map(f -> "Video file: " + f.getContent());
+        return file.getType() == File.Type.VIDEO ?
+               Optional.of("Video file: " + file.getContent()) :
+               Optional.empty();
     }
 
     public static void main( String[] args ) {
@@ -40,8 +40,7 @@ public class ChainOfRespLambda {
                 ChainOfRespLambda::parseAudio,
                 ChainOfRespLambda::parseVideo )
                 .map(f -> f.apply( file ))
-                .filter( Optional::isPresent )
-                .map( Optional::get )
+                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty)) // jdk9: Optional#stream()
                 .findFirst()
                 .orElseThrow( () -> new RuntimeException( "Unknown file: " + file ) )
         );


### PR DESCRIPTION
I think #3 was not a good fix because we should:
 - not use soon-to-be-deprecated Optional#get (use flatMap instead, jdk9 will explicitly support this pattern)
 - assume all arguments are non-null: passing null arguments is insane and should not be covered for because it is a programming error.