### PR TITLE
Fixed 'responsibility' spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-g ∘ f patterns - (aka From Gof to lambda)
+# g ∘ f patterns (aka From Gof to lambda)
 
-Pattern                | Lambda
----------------------- | --------------
-Command                | Functions
-Strategy               | Functions
-Template               | Consumer
-Observer               | Consumer
-Decorator              | Functions composition
-Chain of Resposibility | Stream of functions
-Interpreter            | Map of functions
-Visitor                | Pattern matching + Functions
+## by [Mario Fusco](https://twitter.com/mariofusco)
 
-by [Mario Fusco](https://twitter.com/mariofusco) 
+Pattern                 | Lambda
+----------------------- | --------------
+Command                 | Functions
+Strategy                | Functions
+Template                | Consumer
+Observer                | Consumer
+Decorator               | Functions composition
+Chain of Responsibility | Stream of functions
+Interpreter             | Map of functions
+Visitor                 | Pattern matching + Functions
+
 
 The video of talk where I implemented this patterns in a live coding session is available [here](https://www.youtube.com/watch?v=lZG74WbnhoE).
 


### PR DESCRIPTION
I also changed the header for the readme and moved the
link of the author to the h2 heading.